### PR TITLE
Update activity_main.xml

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,7 +28,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        app:srcCompat="@drawable/empty_dice" />
+        app:srcCompat="@drawable/empty_dice"
+        tools:srcCompat="@drawable/dice_1" />
 
     <Button
         android:id="@+id/roll_button"


### PR DESCRIPTION
when you updated to srcCompat, you removed the tools displaying the dice1 image in the design. I have proposed to add the srcCompat version as in tools:srcCompat="@drawable/dice_1". You then see the dice image in the design, and a blank image when running the app.